### PR TITLE
[REVIEW] - Issue 159 - Modify session_votes view to link titles to review pages.

### DIFF
--- a/config/sync/views.view.session_votes.yml
+++ b/config/sync/views.view.session_votes.yml
@@ -30,6 +30,59 @@ display:
     position: 0
     display_options:
       fields:
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: 'Link to Content'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: view
+          output_url_as_text: true
+          absolute: false
         title:
           id: title
           table: node_field_data
@@ -43,8 +96,8 @@ display:
           label: Title
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '<a href="{{ view_node }}/review">{{ title }}</a>'
             make_link: false
             path: ''
             absolute: false
@@ -84,7 +137,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
Uses a hook to redirect session title links from canonical URLs to /review URLs for easier admin review/voting.

*Update: chatted with Phil, scrapped the hook and instead updated the Session Votes view to link to the /review pages