### PR TITLE
[REVIEW] - Issue 185 - adjustments to redirecting and permissions for comments

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.restricted_html
   module:
-    - comment
     - contact
     - filter
     - media
@@ -18,7 +17,6 @@ label: 'Anonymous user'
 weight: 0
 is_admin: false
 permissions:
-  - 'access comments'
   - 'access content'
   - 'access site-wide contact form'
   - 'search content'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -10,7 +10,6 @@ dependencies:
     - node.type.speaker
     - workflows.workflow.session_workflow
   module:
-    - comment
     - contact
     - content_moderation
     - entity_browser
@@ -29,7 +28,6 @@ label: 'Authenticated user'
 weight: 1
 is_admin: false
 permissions:
-  - 'access comments'
   - 'access content'
   - 'access inline_speaker_form entity browser pages'
   - 'access shortcuts'
@@ -39,9 +37,7 @@ permissions:
   - 'delete own files'
   - 'edit own session content'
   - 'edit own speaker content'
-  - 'post comments'
   - 'search content'
-  - 'skip comment approval'
   - 'use  The form mode speaker linked to  node entity( session )'
   - 'use  The form mode speaker linked to  node entity( speaker )'
   - 'use session_workflow transition edit_accepted'

--- a/config/sync/user.role.reviewer.yml
+++ b/config/sync/user.role.reviewer.yml
@@ -25,6 +25,7 @@ weight: 2
 is_admin: false
 permissions:
   - 'access administration pages'
+  - 'access comments'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'
@@ -41,8 +42,10 @@ permissions:
   - 'edit own comments'
   - 'edit own field_session_votes'
   - 'edit own page content'
+  - 'post comments'
   - 'rate content'
   - 'revert all revisions'
+  - 'skip comment approval'
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view field_session_votes'

--- a/web/modules/custom/sessions/sessions.module
+++ b/web/modules/custom/sessions/sessions.module
@@ -23,23 +23,57 @@ function sessions_node_insert(EntityInterface $entity): void
 }
 
 /**
+ * Implements hook_comment_insert().
+ * 
+ * Redirects back to /review page after posting a comment or reply.
+ */
+function sessions_comment_insert(EntityInterface $entity) {
+  _sessions_redirect_to_review($entity);
+}
+
+/**
  * Implements hook_form_alter().
+ * 
+ * When posting comment, redirect to /review.
  */
 function sessions_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ($form_id === 'comment_comment_form') {
-    // Add our own submit handler at the end of the queue.
-    $form['#submit'][] = 'sessions_comment_comment_form_redirect';
+  // Handle posting comment, editing, replying, and delete.
+  if ($form_id === 'comment_comment_form' || $form_id === 'comment_comment_delete_form') {
+    $form['actions']['submit']['#submit'][] = '_sessions_comment_form_redirect_to_review';
   }
 }
 
 /**
- * Custom submit handler to override the final redirect.
+ * Custom submit handler to redirect session comments to /review page.
  */
-function sessions_comment_comment_form_redirect(array &$form, FormStateInterface $form_state) {
-  $current_path = \Drupal::service('path.current')->getPath();
+function _sessions_comment_form_redirect_to_review(array &$form, FormStateInterface $form_state) {
+  $comment = $form_state->getFormObject()->getEntity();
+  
+  if ($comment && $comment->getCommentedEntity()) {
+    $commented_entity = $comment->getCommentedEntity();
+    
+    // For session comments, always redirect to /review.
+    if ($commented_entity instanceof NodeInterface && $commented_entity->bundle() === 'session') {
+      $review_url = $commented_entity->toUrl('canonical', ['absolute' => FALSE])->toString() . '/review';
+      $form_state->setRedirectUrl(Url::fromUserInput($review_url));
+    }
+  }
+}
 
-  // Only adjust if the user was on a /review page.
-  if (str_ends_with($current_path, '/review')) {
-    $form_state->setRedirectUrl(Url::fromUserInput($current_path));
+/**
+ * Helper function to redirect to /review page after posting a new comment.
+ */
+function _sessions_redirect_to_review(EntityInterface $entity) {
+  $commented_entity = $entity->getCommentedEntity();
+  
+  // For session comments, always redirect to /review (no anchor).
+  if ($commented_entity instanceof NodeInterface && $commented_entity->bundle() === 'session') {
+
+    $review_url = $commented_entity->toUrl('canonical', ['absolute' => FALSE])->toString() . '/review';
+    
+    // Set the redirect response.
+    $response = new RedirectResponse($review_url);
+    $response->send();
+    exit;
   }
 }


### PR DESCRIPTION
Added hook for redirecting back to /review after posting, editing, deleting, and replying to comments. 

Also realized I didn't export the configuration for comment permissions in a previous PR, so adding them here. Comments limited only to reviewers and administrators. 