### PR TITLE
Issue 182: updates to speaker page mod state and event tag

### DIFF
--- a/config/sync/views.view.event_speakers.yml
+++ b/config/sync/views.view.event_speakers.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - core.entity_view_mode.node.summary_card
     - node.type.speaker
+    - workflows.workflow.session_workflow
   module:
+    - content_moderation
     - node
     - user
 id: event_speakers
@@ -261,6 +263,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: reverse__node__field_speakers_ref
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            session_workflow-published: session_workflow-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
         options:
@@ -314,7 +357,8 @@ display:
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   summary_cards:
     id: summary_cards
     display_title: Block
@@ -331,4 +375,5 @@ display:
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'

--- a/config/sync/views.view.speaker_sessions.yml
+++ b/config/sync/views.view.speaker_sessions.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.speaker_session
     - node.type.session
   module:
+    - datetime
     - node
     - user
 id: speaker_sessions
@@ -104,7 +105,21 @@ display:
           empty: true
           content: "This Speaker doesn't have any presentations."
           tokenize: false
-      sorts: {  }
+      sorts:
+        field_event_date_value:
+          id: field_event_date_value
+          table: node__field_event_date
+          field: field_event_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
       arguments:
         field_speakers_ref_target_id:
           id: field_speakers_ref_target_id

--- a/web/themes/custom/scale/dist/css/styles.css
+++ b/web/themes/custom/scale/dist/css/styles.css
@@ -314,6 +314,26 @@ menu {
   padding: 0;
 }
 
+/* Pager: align items horizontally */
+.pager__items {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+  padding-left: 0;
+  margin: 1rem 0;
+}
+
+/* remove default list spacing */
+.pager__item {
+  margin: 0;
+}
+
+.pager__item.is-active a {
+  font-weight: 700;
+}
+
 /*
 Reset default styling for dialogs.
 */

--- a/web/themes/custom/scale/templates/node/node--session--speaker-session.html.twig
+++ b/web/themes/custom/scale/templates/node/node--session--speaker-session.html.twig
@@ -1,10 +1,13 @@
+{% if node.isPublished() %}
+
 <div class="mb-8">
   <div class="flex items-center gap-2 mb-2">
     <span class="text-sm bg-amber-200 py-1 px-3 font-body rounded">
       {{ node.field_scale_event.0.entity.label }}
     </span>
+
     <h3>{{ node.label }}</h3>
-    {% if moderation_state_label %}
+    {% if moderation_state_label and user.hasPermission('view any unpublished content') %}
       <span class="text-sm bg-blue-50 text-blue-500 py-1 px-3 font-body rounded">
         {{ moderation_state_label }}
       </span>
@@ -24,3 +27,5 @@
   </div>
   <a href="{{ url }}" class="btn btn-black">See Presentation</a>
 </div>
+
+{% endif %}


### PR DESCRIPTION
Updated speaker session to view to sort accepted/published talks by descending order, and updated speaker session twig file to only show mod state tag for admins, and only show published talks.