### PR TITLE
issue #182: adjusted viewing access for moderation state label on session pages

### DIFF
--- a/web/themes/custom/scale/templates/components/hero/hero-block--session.html.twig
+++ b/web/themes/custom/scale/templates/components/hero/hero-block--session.html.twig
@@ -2,7 +2,7 @@
 
 
 {% block hero__bottom %}
-  {% if moderation_state_label %}
+  {% if moderation_state_label and user.hasPermission('view any unpublished content') %}
     <div class="mb-5">
       <span class="text-sm bg-blue-50 text-blue-500 py-1 px-3 font-body rounded">
         {{ moderation_state_label }}


### PR DESCRIPTION
Added condition to moderation state tag to be viewable only for users who can "view all unpublished content."