### PR TITLE
issue #288 updated file settings and twig file to fix encoding

### DIFF
--- a/config/sync/file.settings.yml
+++ b/config/sync/file.settings.yml
@@ -8,7 +8,7 @@ icon:
 make_unused_managed_files_temporary: false
 filename_sanitization:
   transliterate: false
-  replace_whitespace: false
+  replace_whitespace: true
   replace_non_alphanumeric: false
   deduplicate_separators: false
   lowercase: false

--- a/web/themes/custom/scale/templates/node/node--session.html.twig
+++ b/web/themes/custom/scale/templates/node/node--session.html.twig
@@ -30,7 +30,9 @@
   <div class="my-7">
     {% if node.field_assets is not empty %}
       {% set file_url = node.field_assets.entity.uri.value|file_url %}
-      {{ drupal_link('Presentation'|t, file_url, {attributes: {class: ['btn', 'btn-black'], target: '_blank', download}}) }}
+      <a href="{{ file_url }}" class="btn btn-black" target="_blank">
+        {{ 'Presentation' | t }}
+      </a>
     {% endif %}
   </div>
 


### PR DESCRIPTION
Used `<a href>` instead of drupal_link(). also enabled file settings to fill white space in file names with "-".