### PR TITLE
[READY]-[ISSUE-200]-Change comments to have only 1 field

### DIFF
--- a/config/sync/core.entity_form_display.comment.comment.default.yml
+++ b/config/sync/core.entity_form_display.comment.comment.default.yml
@@ -15,22 +15,17 @@ bundle: comment
 mode: default
 content:
   author:
-    weight: -2
+    weight: 0
     region: content
+    settings: {  }
+    third_party_settings: {  }
   comment_body:
     type: text_textarea
-    weight: 11
+    weight: 1
     region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  subject:
-    type: string_textfield
-    weight: 10
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-hidden: {  }
+hidden:
+  subject: true

--- a/web/themes/custom/scale/templates/comments/comment.html.twig
+++ b/web/themes/custom/scale/templates/comments/comment.html.twig
@@ -98,11 +98,6 @@
 {# renders the comment content #}
 
   <div{{ content_attributes }}>
-    {% if comment.getSubject() %}
-      {{ title_prefix }}
-      <h3>{{ comment.getSubject() }}</h3>
-      {{ title_suffix }}
-    {% endif %}
     {{ content }}
   </div>
 </article>


### PR DESCRIPTION
## What this does
Hides the Subject field on the comment form so reviewers just fill in one field instead of two.

## Why
People were pasting the same text into both Subject and Comment since both were required. This issue asked for just one field.

## Changes
Updated core.entity_form_display.comment.comment.default.yml to move Subject to Disabled on the comment form. Updated comment.html.twig to remove the auto-generated subject heading, which was showing up as a duplicate of the comment text once Subject got hidden.

## Testing
Tested locally. Comments now show one field and look clean after saving.

## Screenshot
<img width="503" height="613" alt="issue-200-single-comment-field" src="https://github.com/user-attachments/assets/ed11f9e0-b187-4025-9983-6e4f3a1a189b" />

Closes #200