### PR TITLE
[REVIEW]-[ISSUE-242]-Add social media links to speaker profiles

### DIFF
--- a/config/sync/core.entity_form_display.node.speaker.default.yml
+++ b/config/sync/core.entity_form_display.node.speaker.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -31,6 +32,7 @@ dependencies:
     - content_moderation
     - image
     - link
+    - paragraphs
     - path
     - text
 id: node.speaker.default
@@ -40,7 +42,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 19
+    weight: 20
     region: content
     settings:
       rows: 9
@@ -56,13 +58,13 @@ content:
     third_party_settings: {  }
   field_age:
     type: options_select
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   field_education:
     type: options_select
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -76,13 +78,13 @@ content:
     third_party_settings: {  }
   field_employment_status:
     type: options_select
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   field_ethnicity:
     type: options_select
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -96,13 +98,13 @@ content:
     third_party_settings: {  }
   field_gender:
     type: options_select
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_household_income:
     type: options_select
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -124,7 +126,7 @@ content:
     third_party_settings: {  }
   field_marital_status:
     type: options_select
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -138,7 +140,7 @@ content:
     third_party_settings: {  }
   field_phone:
     type: string_textfield
-    weight: 20
+    weight: 21
     region: content
     settings:
       size: 60
@@ -146,7 +148,7 @@ content:
     third_party_settings: {  }
   field_postal_code:
     type: string_textfield
-    weight: 16
+    weight: 17
     region: content
     settings:
       size: 60
@@ -154,7 +156,7 @@ content:
     third_party_settings: {  }
   field_profile_photo:
     type: image_image
-    weight: 9
+    weight: 10
     region: content
     settings:
       progress_indicator: throbber
@@ -166,6 +168,26 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_social_media_links:
+    type: paragraphs
+    weight: 9
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: social_media_link
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: duplicate
     third_party_settings: {  }
   field_speaker_agreement:
     type: boolean_checkbox
@@ -184,7 +206,7 @@ content:
     third_party_settings: {  }
   field_user_account:
     type: entity_reference_autocomplete_tags
-    weight: 10
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -202,33 +224,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 27
+    weight: 28
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 22
+    weight: 23
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 25
+    weight: 26
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 23
+    weight: 24
     region: content
     settings:
       display_label: true
@@ -243,7 +265,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 21
+    weight: 22
     region: content
     settings:
       match_operator: CONTAINS
@@ -252,7 +274,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 26
+    weight: 27
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.speaker.speaker.yml
+++ b/config/sync/core.entity_form_display.node.speaker.speaker.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -32,6 +33,7 @@ dependencies:
     - content_moderation
     - image
     - link
+    - paragraphs
     - path
     - text
 id: node.speaker.speaker
@@ -51,7 +53,7 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -168,6 +170,26 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_social_media_links:
+    type: paragraphs
+    weight: 19
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: social_media_link
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: duplicate
+    third_party_settings: {  }
   field_speaker_agreement:
     type: boolean_checkbox
     weight: 27
@@ -193,33 +215,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 25
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 21
+    weight: 22
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 26
+    weight: 27
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 22
+    weight: 23
     region: content
     settings:
       display_label: true
@@ -234,7 +256,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 19
+    weight: 20
     region: content
     settings:
       match_operator: CONTAINS
@@ -243,7 +265,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.paragraph.social_media_link.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.social_media_link.default.yml
@@ -1,0 +1,32 @@
+uuid: 78b82409-edd6-4800-a7a6-78c8fa58f9f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.social_media_link.field_platform
+    - field.field.paragraph.social_media_link.field_url
+    - paragraphs.paragraphs_type.social_media_link
+  module:
+    - link
+id: paragraph.social_media_link.default
+targetEntityType: paragraph
+bundle: social_media_link
+mode: default
+content:
+  field_platform:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_url:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_view_display.node.speaker.default.yml
+++ b/config/sync/core.entity_view_display.node.speaker.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -28,6 +29,7 @@ dependencies:
     - image.style.large
     - node.type.speaker
   module:
+    - entity_reference_revisions
     - image
     - link
     - text
@@ -183,6 +185,15 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 122
+    region: content
+  field_social_media_links:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 121
     region: content
   field_speaker_agreement:
     type: boolean

--- a/config/sync/core.entity_view_display.node.speaker.listing_small.yml
+++ b/config/sync/core.entity_view_display.node.speaker.listing_small.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -146,4 +147,5 @@ hidden:
   field_phone: true
   field_postal_code: true
   field_recording_consent: true
+  field_social_media_links: true
   field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.profile_card.yml
+++ b/config/sync/core.entity_view_display.node.speaker.profile_card.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -146,4 +147,5 @@ hidden:
   field_phone: true
   field_postal_code: true
   field_recording_consent: true
+  field_social_media_links: true
   field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.summary_card.yml
+++ b/config/sync/core.entity_view_display.node.speaker.summary_card.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -146,4 +147,5 @@ hidden:
   field_phone: true
   field_postal_code: true
   field_recording_consent: true
+  field_social_media_links: true
   field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.teaser.yml
+++ b/config/sync/core.entity_view_display.node.speaker.teaser.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -67,6 +68,7 @@ hidden:
   field_postal_code: true
   field_profile_photo: true
   field_recording_consent: true
+  field_social_media_links: true
   field_speaker_agreement: true
   field_twitter_profile: true
   field_user_account: true

--- a/config/sync/core.entity_view_display.node.speaker.user_speaker.yml
+++ b/config/sync/core.entity_view_display.node.speaker.user_speaker.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
     - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_social_media_links
     - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
@@ -73,6 +74,7 @@ hidden:
   field_phone: true
   field_postal_code: true
   field_recording_consent: true
+  field_social_media_links: true
   field_speaker_agreement: true
   field_twitter_profile: true
   field_user_account: true

--- a/config/sync/core.entity_view_display.paragraph.social_media_link.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.social_media_link.default.yml
@@ -1,0 +1,37 @@
+uuid: b2adb63e-4928-478f-907b-3aac29c24b4b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.social_media_link.field_platform
+    - field.field.paragraph.social_media_link.field_url
+    - paragraphs.paragraphs_type.social_media_link
+  module:
+    - link
+id: paragraph.social_media_link.default
+targetEntityType: paragraph
+bundle: social_media_link
+mode: default
+content:
+  field_platform:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_url:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  breadcrumbs: true

--- a/config/sync/field.field.node.speaker.field_social_media_links.yml
+++ b/config/sync/field.field.node.speaker.field_social_media_links.yml
@@ -1,0 +1,55 @@
+uuid: 5add3440-f4f5-4d82-9d0f-76eafbc8bd3d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_social_media_links
+    - node.type.speaker
+    - paragraphs.paragraphs_type.social_media_link
+  module:
+    - entity_reference_revisions
+id: node.speaker.field_social_media_links
+field_name: field_social_media_links
+entity_type: node
+bundle: speaker
+label: 'Social Media Links'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      social_media_link: social_media_link
+    negate: 0
+    target_bundles_drag_drop:
+      event_exhibitors:
+        weight: 10
+        enabled: false
+      event_sessions:
+        weight: 11
+        enabled: false
+      event_sessions_list:
+        weight: 12
+        enabled: false
+      event_sponsors:
+        weight: 13
+        enabled: false
+      featured_speakers:
+        weight: 14
+        enabled: false
+      latest_articles:
+        weight: 15
+        enabled: false
+      rich_text:
+        weight: 16
+        enabled: false
+      social_media_link:
+        weight: 17
+        enabled: true
+      speakers:
+        weight: 18
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.paragraph.social_media_link.field_platform.yml
+++ b/config/sync/field.field.paragraph.social_media_link.field_platform.yml
@@ -1,0 +1,29 @@
+uuid: e5f138d0-829e-42a1-9d19-3835b8456512
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_platform
+    - paragraphs.paragraphs_type.social_media_link
+    - taxonomy.vocabulary.social_media_platforms
+id: paragraph.social_media_link.field_platform
+field_name: field_platform
+entity_type: paragraph
+bundle: social_media_link
+label: Platform
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      social_media_platforms: social_media_platforms
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.social_media_link.field_url.yml
+++ b/config/sync/field.field.paragraph.social_media_link.field_url.yml
@@ -1,0 +1,23 @@
+uuid: 2bc75302-2566-446a-86e2-5208a48fca8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_url
+    - paragraphs.paragraphs_type.social_media_link
+  module:
+    - link
+id: paragraph.social_media_link.field_url
+field_name: field_url
+entity_type: paragraph
+bundle: social_media_link
+label: URL
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.storage.node.field_social_media_links.yml
+++ b/config/sync/field.storage.node.field_social_media_links.yml
@@ -1,0 +1,21 @@
+uuid: 0c452617-64bd-4baa-a960-0d258c092d8a
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_social_media_links
+field_name: field_social_media_links
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 10
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_platform.yml
+++ b/config/sync/field.storage.paragraph.field_platform.yml
@@ -1,0 +1,20 @@
+uuid: 192205a3-8f71-4cb6-b8fb-4136272b1693
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_platform
+field_name: field_platform
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.field_url.yml
+++ b/config/sync/field.storage.paragraph.field_url.yml
@@ -1,0 +1,19 @@
+uuid: c5c2990a-ddf1-43b8-93b5-9f9fbdfddf6f
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_url
+field_name: field_url
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/form_mode_control.settings.yml
+++ b/config/sync/form_mode_control.settings.yml
@@ -57,3 +57,4 @@ modification+authenticated+node+speaker: node.speaker.speaker
 modification+reviewer+node+speaker: node.speaker.speaker
 modification+administrator+node+speaker: node.speaker.default
 'use  The form mode default linked to  paragraph entity( event_sessions_list )': paragraph.event_sessions_list.default
+'use  The form mode default linked to  paragraph entity( social_media_link )': paragraph.social_media_link.default

--- a/config/sync/paragraphs.paragraphs_type.social_media_link.yml
+++ b/config/sync/paragraphs.paragraphs_type.social_media_link.yml
@@ -1,0 +1,10 @@
+uuid: eb7de250-d537-46cf-a9b4-c6c6c4cd8850
+langcode: en
+status: true
+dependencies: {  }
+id: social_media_link
+label: 'Social Media Link'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/sync/taxonomy.vocabulary.social_media_platforms.yml
+++ b/config/sync/taxonomy.vocabulary.social_media_platforms.yml
@@ -1,0 +1,9 @@
+uuid: ceba96c8-1f6d-4143-b440-088ee9c8efac
+langcode: en
+status: true
+dependencies: {  }
+name: 'Social Media Platforms'
+vid: social_media_platforms
+description: 'Platforms available for speaker social media links'
+weight: 0
+new_revision: false

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -38,6 +38,7 @@ permissions:
   - 'edit own session content'
   - 'edit own speaker content'
   - 'search content'
+  - 'use  The form mode default linked to  paragraph entity( social_media_link )'
   - 'use  The form mode speaker linked to  node entity( session )'
   - 'use  The form mode speaker linked to  node entity( speaker )'
   - 'use session_workflow transition edit_accepted'

--- a/config/sync/views.view.speaker_social_links.yml
+++ b/config/sync/views.view.speaker_social_links.yml
@@ -1,0 +1,483 @@
+uuid: bc6c2038-e406-465d-b615-513769bbacb4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_url
+    - node.type.speaker
+    - user.role.administrator
+  module:
+    - csv_serialization
+    - link
+    - node
+    - paragraphs
+    - rest
+    - serialization
+    - taxonomy
+    - user
+    - views_data_export
+id: speaker_social_links
+label: 'Speaker Social Links'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: 'Speaker Name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: 'Speaker ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: field_platform
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: Platform
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+        field_url:
+          id: field_url
+          table: paragraph__field_url
+          field: field_url
+          relationship: field_social_media_links
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Profile URL'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: true
+            url_plain: true
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            speaker: speaker
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+          columns: {  }
+          default: ''
+          info: {  }
+          override: true
+          sticky: false
+          summary: ''
+          order: asc
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        field_social_media_links:
+          id: field_social_media_links
+          table: node__field_social_media_links
+          field: field_social_media_links
+          relationship: none
+          group_type: group
+          admin_label: 'social link'
+          plugin_id: standard
+          required: true
+        field_platform:
+          id: field_platform
+          table: paragraph__field_platform
+          field: field_platform
+          relationship: field_social_media_links
+          group_type: group
+          admin_label: 'platform term '
+          plugin_id: standard
+          required: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.paragraph.field_url'
+  data_export_1:
+    id: data_export_1
+    display_title: 'Data export'
+    display_plugin: data_export
+    position: 1
+    display_options:
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+            output_header: true
+          xml_settings:
+            encoding: UTF-8
+            root_node_name: response
+            item_node_name: item
+            format_output: false
+      display_extenders: {  }
+      path: admin/export/speaker-social-links
+      auth:
+        - cookie
+      filename: 'speaker-social-links--[date:html_datetime].csv'
+      automatic_download: false
+      store_in_public_file_directory: null
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.paragraph.field_url'

--- a/web/themes/custom/scale/templates/node/node--speaker.html.twig
+++ b/web/themes/custom/scale/templates/node/node--speaker.html.twig
@@ -16,6 +16,25 @@
         </a>
       </div>
     {% endif %}
+
+    {% set social_icons = {
+      'Mastodon': 'fa-mastodon',
+      'X': 'fa-x-twitter',
+      'Bluesky': 'fa-bluesky',
+      'LinkedIn': 'fa-linkedin-in',
+      'Facebook': 'fa-facebook-f',
+      'Instagram': 'fa-instagram',
+      'GitHub': 'fa-github',
+    } %}
+    {% for item in node.field_social_media_links %}
+      {% set platform = item.entity.field_platform.entity.label %}
+      {% set icon = social_icons[platform]|default('fa-share-nodes') %}
+      <div class="text-2xl">
+        <a href="{{ item.entity.field_url.uri }}" target="_blank" class="text-black" title="{{ platform }}">
+          <i class="fa-brands {{ icon }}"></i>
+        </a>
+      </div>
+    {% endfor %}
   </div>
 
   <div class="text-2xl mb-12">


### PR DESCRIPTION
## Summary

Speakers can add social media links to their profile. Platforms are taxonomy terms instead of hardcoded fields, so an admin can add a new one through the UI without a code change. 1 of 3. Next is the migration script for existing Twitter values, then taking the old Twitter field off the form and the profile.

Uses Paragraphs and Views Data Export, both already installed. No custom code.

- `social_media_platforms` vocabulary: Mastodon, X, Bluesky, LinkedIn, Facebook, Instagram, GitHub
- `social_media_link` paragraph type: platform + URL
- `field_social_media_links` on Speaker, up to 10 per profile
- Enabled on both admin and speaker form displays, with the form-mode permission granted to authenticated users so speakers can edit their own
- Icons on speaker profiles, styled to match the existing website/Twitter icons
- CSV export at `/admin/export/speaker-social-links`, Administrator only

## Screenshot

<img width="750" height="372" alt="speaker-profile-social-icons" src="https://github.com/user-attachments/assets/ac686223-ef8a-43b8-87b9-765c93d2db27" />

This speaker has both the legacy Twitter field and the new field filled in, which is why there are two X icons. See below.

## Export output

```
"Speaker Name","Speaker ID",Platform,"Profile URL"
"Test Speaker",28001,Mastodon,https://example.com/mastodon
"Test Speaker",28001,X,https://example.com/x
"Test Speaker",28001,Bluesky,https://example.com/bluesky
"Test Speaker",28001,LinkedIn,https://example.com/linkedin
"Test Speaker",28001,Facebook,https://example.com/facebook
```

One row per link so it can be filtered by platform in a spreadsheet.

## The old Twitter field

I left `field_twitter_profile` alone, so nothing changes for the 1,174 speakers who already have a value there. Until the migration runs, anyone who fills in both fields gets a duplicate icon, and the export only reads the new field.

Next PR migrates those values across, then a third takes the old field off the form and the profile. The field itself stays so the original values are still there.

## After merge

The 7 platform terms need adding at `/admin/structure/taxonomy/manage/social_media_platforms/overview`, since
terms don't export with config.

## Testing

Tested as a non-admin user which caught that the field was hidden on the speaker form mode. Confirmed speakers can see and save their own links, icons render for anonymous visitors, CSV output is correct, and anonymous requests to the export return 403.