### PR TITLE
[READY]-[ISSUE-290]- Added checkboxes in Speaker profile creation for Speaker Agreement and consent to recording/livestream

### DIFF
--- a/config/sync/core.entity_form_display.node.speaker.default.yml
+++ b/config/sync/core.entity_form_display.node.speaker.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -157,6 +159,20 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_recording_consent:
+    type: boolean_checkbox
+    weight: 29
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_speaker_agreement:
+    type: boolean_checkbox
+    weight: 28
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_twitter_profile:
     type: link_default

--- a/config/sync/core.entity_form_display.node.speaker.speaker.yml
+++ b/config/sync/core.entity_form_display.node.speaker.speaker.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -158,6 +160,20 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_recording_consent:
+    type: boolean_checkbox
+    weight: 28
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_speaker_agreement:
+    type: boolean_checkbox
+    weight: 27
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_twitter_profile:
     type: link_default

--- a/config/sync/core.entity_view_display.node.speaker.default.yml
+++ b/config/sync/core.entity_view_display.node.speaker.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -171,6 +173,26 @@ content:
         attribute: lazy
     third_party_settings: {  }
     weight: 109
+    region: content
+  field_recording_consent:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 122
+    region: content
+  field_speaker_agreement:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 121
     region: content
   field_twitter_profile:
     type: link

--- a/config/sync/core.entity_view_display.node.speaker.listing_small.yml
+++ b/config/sync/core.entity_view_display.node.speaker.listing_small.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -143,3 +145,5 @@ hidden:
   field_marital_status: true
   field_phone: true
   field_postal_code: true
+  field_recording_consent: true
+  field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.profile_card.yml
+++ b/config/sync/core.entity_view_display.node.speaker.profile_card.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -143,3 +145,5 @@ hidden:
   field_marital_status: true
   field_phone: true
   field_postal_code: true
+  field_recording_consent: true
+  field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.summary_card.yml
+++ b/config/sync/core.entity_view_display.node.speaker.summary_card.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -143,3 +145,5 @@ hidden:
   field_marital_status: true
   field_phone: true
   field_postal_code: true
+  field_recording_consent: true
+  field_speaker_agreement: true

--- a/config/sync/core.entity_view_display.node.speaker.teaser.yml
+++ b/config/sync/core.entity_view_display.node.speaker.teaser.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -64,6 +66,8 @@ hidden:
   field_phone: true
   field_postal_code: true
   field_profile_photo: true
+  field_recording_consent: true
+  field_speaker_agreement: true
   field_twitter_profile: true
   field_user_account: true
   field_website: true

--- a/config/sync/core.entity_view_display.node.speaker.user_speaker.yml
+++ b/config/sync/core.entity_view_display.node.speaker.user_speaker.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.speaker.field_phone
     - field.field.node.speaker.field_postal_code
     - field.field.node.speaker.field_profile_photo
+    - field.field.node.speaker.field_recording_consent
+    - field.field.node.speaker.field_speaker_agreement
     - field.field.node.speaker.field_twitter_profile
     - field.field.node.speaker.field_user_account
     - field.field.node.speaker.field_website
@@ -70,6 +72,8 @@ hidden:
   field_organization: true
   field_phone: true
   field_postal_code: true
+  field_recording_consent: true
+  field_speaker_agreement: true
   field_twitter_profile: true
   field_user_account: true
   field_website: true

--- a/config/sync/field.field.node.speaker.field_recording_consent.yml
+++ b/config/sync/field.field.node.speaker.field_recording_consent.yml
@@ -1,0 +1,21 @@
+uuid: f5a820cd-39a1-4c48-8dcd-2d3fd0050d5f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_recording_consent
+    - node.type.speaker
+id: node.speaker.field_recording_consent
+field_name: field_recording_consent
+entity_type: node
+bundle: speaker
+label: 'Recording & Livestream Consent'
+description: 'By selecting this, I understand that all talks are recorded and livestreamed.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.node.speaker.field_speaker_agreement.yml
+++ b/config/sync/field.field.node.speaker.field_speaker_agreement.yml
@@ -1,0 +1,21 @@
+uuid: e1c74555-b843-48c5-9ae6-fcee08a167dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_speaker_agreement
+    - node.type.speaker
+id: node.speaker.field_speaker_agreement
+field_name: field_speaker_agreement
+entity_type: node
+bundle: speaker
+label: 'Speaker Agreement & Code of Conduct'
+description: 'By selecting this, I acknowledge that I have read and abide by the terms of the <a href=https://www.socallinuxexpo.org/scale/24x/speaker-agreement>Speaker Agreement</a> and <a href=https://www.socallinuxexpo.org/scale/24x/code-conduct>Code of Conduct</a>.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.node.field_recording_consent.yml
+++ b/config/sync/field.storage.node.field_recording_consent.yml
@@ -1,0 +1,18 @@
+uuid: d691cbdd-580e-47b0-b37c-57c477b6cee5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_recording_consent
+field_name: field_recording_consent
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_speaker_agreement.yml
+++ b/config/sync/field.storage.node.field_speaker_agreement.yml
@@ -1,0 +1,18 @@
+uuid: b2c3a4b6-82fb-41d2-8046-71c40c4c6b22
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_speaker_agreement
+field_name: field_speaker_agreement
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -11,8 +11,8 @@ label: Administrator
 weight: 3
 is_admin: true
 permissions:
-  - 'create field_session_votes'
-  - 'edit field_session_votes'
-  - 'edit own field_session_votes'
-  - 'view field_session_votes'
-  - 'view own field_session_votes'
+  - 'create field_recording_consent'
+  - 'edit field_recording_consent'
+  - 'edit own field_recording_consent'
+  - 'view field_recording_consent'
+  - 'view own field_recording_consent'

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -11,8 +11,8 @@ label: Administrator
 weight: 3
 is_admin: true
 permissions:
-  - 'create field_recording_consent'
-  - 'edit field_recording_consent'
-  - 'edit own field_recording_consent'
-  - 'view field_recording_consent'
-  - 'view own field_recording_consent'
+  - 'create field_session_votes'
+  - 'edit field_session_votes'
+  - 'edit own field_session_votes'
+  - 'view field_session_votes'
+  - 'view own field_session_votes'


### PR DESCRIPTION
### Issue

Speakers need to agree to the Speaker Agreement and Code of Conduct, and acknowledge that talks are recorded/livestreamed, when a Speaker profile is created.

### Changes

Added two required boolean fields to the Speaker content type:
- `field_speaker_agreement` — Speaker Agreement & Code of Conduct
- `field_recording_consent` — Recording & Livestream Consent

Both fields use a toggle widget with help text linking directly to the Speaker Agreement and Code of Conduct pages, so no custom form-alter hooks were needed to inject links into the label.

Confirmed via testing with a speaker account that fields display and save correctly on the speaker/rep form display.

### Screenshot of what Speaker sees at the bottom to agree to both terms:
<img width="1880" height="848" alt="Screenshot 2026-08-03 at 6 00 05 PM" src="https://github.com/user-attachments/assets/b282a111-fc31-4f25-bd2e-15b9b1a7f695" />

### Notes

- If a talk is submitted on behalf of a speaker who agrees to these terms for them, the speaker would still receive a confirmation email notifying them that the talk has been submitted, and that they have agreed to all the terms (related to issue #180) 
- links to the 24x Speaker Agreement and Code of Conduct are not yet published on prod, but the links will display the correct content when they are live.
