### PR TITLE
[READY]-[ISSUE-242]-Migrate legacy Twitter values to social media links

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,97 @@
+# Migrations
+
+One off data migrations, newest first. Each section covers what ran, how to verify it,
+and how to undo it.
+
+## Social links migration, issue #242
+
+Migrates legacy `field_twitter_profile` values into `field_social_media_links`.
+Script: `migrate-twitter-to-social-links.php`.
+
+**Status:** not yet run on production.
+Once it has run everywhere the script can be deleted. Leave this section as the record
+of what happened.
+
+Safe to rerun. It skips speakers who already have that platform, so an interrupted run
+is fixed by running it again. It does not delete anything, create node revisions, or
+send email.
+
+Writes to `paragraphs_item_field_data`, `paragraph__field_platform`,
+`paragraph__field_url` and `node__field_social_media_links`. Leaves the old Twitter
+field untouched.
+
+### Prerequisites
+
+- Plain PHP script run through drush. No migrate modules involved.
+- The new field config has to be imported first (`drush cim`).
+- The 7 platform options must exist in the `social_media_platforms` vocabulary. They're
+  content, not config, so they don't arrive with a deploy and have to be created by
+  hand on each environment: `X`, `Mastodon`, `Bluesky`, `LinkedIn`, `Facebook`,
+  `Instagram`, `GitHub`. The script matches by name, so spelling must be exact.
+
+```bash
+drush php:eval "print implode(', ', array_column(\Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree('social_media_platforms'), 'name'));"
+```
+
+- Run before removing `field_twitter_profile`. The script reads it.
+- Check the CLI memory limit. The script loads all matching speakers in one pass.
+
+```bash
+drush php:eval "print ini_get('memory_limit') . PHP_EOL;"
+```
+
+### Execution
+
+Run from the site root. The `--` is required.
+
+```bash
+# 1. back up, and note where new rows will start
+drush sql:dump --gzip --result-file=../pre-social-migration.sql.gz
+drush sql:query "SELECT MAX(id) FROM paragraphs_item_field_data"
+
+# 2. dry run, changes nothing
+drush php:script migrate-twitter-to-social-links.php
+
+# 3. first 5, then check
+drush php:script migrate-twitter-to-social-links.php -- --live --limit=5
+
+# 4. the rest
+drush php:script migrate-twitter-to-social-links.php -- --live
+```
+
+Nearly all should migrate. Skips should be in the low tens, mostly personal sites and
+blogs. Stop at the dry run if it reports `RECOGNIZED BUT NO MATCHING TERM`, migrates
+near zero, or skips hundreds. Nothing has changed at that point.
+
+Some values were stored as `socallinuxexpo.org` URLs rather than the platform's. The
+handle is still usable, so those get rebuilt as `x.com` links. The run reports how many.
+
+Run it once more immediately before the deploy that removes the old field, to catch
+anyone who filled it in since.
+
+### Verification
+
+```bash
+drush sql:query "SELECT COUNT(*) FROM paragraphs_item_field_data WHERE type = 'social_media_link'"
+```
+
+Then open a few speaker profiles. Icons should render as platform logos. A generic
+share symbol means the term name doesn't match the icon map in
+`web/themes/custom/scale/templates/node/node--speaker.html.twig`.
+
+### Rollback
+
+Preferred, removes only what the run created.
+
+Do this through Drupal, not by deleting rows in the database. Deleting rows directly
+leaves speakers pointing at links that no longer exist. Through Drupal: load each
+speaker, remove the links created above the ID from step 1, save, then delete those
+links.
+
+Full restore only if that fails.
+
+```bash
+drush sql:drop -y
+gunzip < ../pre-social-migration.sql.gz | drush sql:cli
+drush cr
+```

--- a/migrate-twitter-to-social-links.php
+++ b/migrate-twitter-to-social-links.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * Migrates legacy field_twitter_profile values into field_social_media_links.
+ *
+ *   drush php:script migrate-twitter-to-social-links.php                      (dry run)
+ *   drush php:script migrate-twitter-to-social-links.php -- --live            (writes)
+ *   drush php:script migrate-twitter-to-social-links.php -- --live --limit=5  (writes 5, stops)
+ *
+ * Take a database backup first. Unrecognized URLs are skipped and reported. Safe to rerun.
+ *
+ * Most values get copied over as-is. The links pointing at socallinuxexpo.org get rebuilt as x.com URLs.
+ *
+ * Remove the old Twitter field and its template block or you end up with two of the same icon.
+ */
+
+$live = in_array('--live', $extra ?? [], TRUE) || in_array('--live', $_SERVER['argv'] ?? [], TRUE);
+
+// --limit=N stops after N speakers, so the first run on prod can be a small one.
+$limit = 0;
+foreach (array_merge($extra ?? [], $_SERVER['argv'] ?? []) as $arg) {
+  if (str_starts_with($arg, '--limit=')) {
+    $limit = (int) substr($arg, 8);
+  }
+}
+
+/**
+ * Work out which platform a URL belongs to by pattern matching.
+ * Returns the platform name and the url to save, or NULL if it isn't a social profile.
+ */
+function scale_detect_platform($uri) {
+  $host = strtolower(parse_url($uri, PHP_URL_HOST) ?: '');
+  $path = parse_url($uri, PHP_URL_PATH) ?: '';
+  $seg = trim($path, '/');
+
+  if ($host === '') {
+    return NULL;
+  }
+
+  // Links to our own site, some with the @, some without. The handle allows us to rebuild as X.
+  if (str_contains($host, 'socallinuxexpo.org')) {
+    $handle = ltrim($seg, '@');
+    // Some people put NA or none instead of leaving it blank.
+    if (in_array(strtolower($handle), ['na', 'n-a', 'none'], TRUE)) {
+      return NULL;
+    }
+    // Real X handles are letters, numbers and underscores, max 15 characters.
+    if (preg_match('/^[A-Za-z0-9_]{1,15}$/', $handle)) {
+      return ['platform' => 'X', 'uri' => 'https://x.com/' . $handle];
+    }
+    return NULL;
+  }
+
+  // Misspelled Twitter.
+  if ($host === 'twiter.com' || $host === 'www.twiter.com') {
+    return ['platform' => 'X', 'uri' => 'https://x.com/' . $seg];
+  }
+
+  // Bluesky: bsky.app, or handle domain like name.bsky.social.
+  if ($host === 'bsky.app' || str_ends_with($host, '.bsky.social')) {
+    return ['platform' => 'Bluesky', 'uri' => $uri];
+  }
+
+  // X / Twitter, including www. and mobile. subdomains.
+  if (str_contains($host, 'twitter.com') || $host === 'x.com' || str_ends_with($host, '.x.com')) {
+    return ['platform' => 'X', 'uri' => $uri];
+  }
+
+  if (str_contains($host, 'linkedin.com')) {
+    return ['platform' => 'LinkedIn', 'uri' => $uri];
+  }
+
+  if (str_contains($host, 'facebook.com')) {
+    return ['platform' => 'Facebook', 'uri' => $uri];
+  }
+
+  if (str_contains($host, 'instagram.com')) {
+    return ['platform' => 'Instagram', 'uri' => $uri];
+  }
+
+  if (str_contains($host, 'github.com')) {
+    return ['platform' => 'GitHub', 'uri' => $uri];
+  }
+
+  // Mastodon has no domain of its own, anyone can run an instance, so the only thing
+  // to match on is the /@username path. That makes it a catch-all, so it goes last.
+  // Ahead of the checks above it would also catch twitter.com/@handle.
+  if (str_starts_with($path, '/@')) {
+    return ['platform' => 'Mastodon', 'uri' => $uri];
+  }
+
+  return NULL;
+}
+
+$etm = \Drupal::entityTypeManager();
+$node_storage = $etm->getStorage('node');
+$term_storage = $etm->getStorage('taxonomy_term');
+
+// Map platform names to their taxonomy term IDs.
+$terms = [];
+foreach ($term_storage->loadTree('social_media_platforms') as $t) {
+  $terms[$t->name] = $t->tid;
+}
+
+$nids = \Drupal::entityQuery('node')
+  ->condition('type', 'speaker')
+  ->exists('field_twitter_profile')
+  ->accessCheck(FALSE)
+  ->execute();
+
+$would = [];
+$skip = [];
+$migrated = 0;
+$already_had = 0;
+$no_term = [];
+$rewritten = 0;
+
+print "\n===== " . ($live ? 'LIVE RUN - WRITING DATA' : 'DRY RUN - NOTHING CHANGED') . ($limit ? " (stopping after $limit)" : '') . " =====\n\n";
+
+foreach ($node_storage->loadMultiple($nids) as $node) {
+  $uri = $node->field_twitter_profile->uri ?? '';
+  if (!$uri) {
+    continue;
+  }
+
+  $detected = scale_detect_platform($uri);
+
+  if ($detected === NULL) {
+    $host = strtolower(parse_url($uri, PHP_URL_HOST) ?: '(unparseable)');
+    $skip[$host] = ($skip[$host] ?? 0) + 1;
+    continue;
+  }
+
+  $platform = $detected['platform'];
+  $store_uri = $detected['uri'];
+
+  if (!isset($terms[$platform])) {
+    $no_term[$platform] = ($no_term[$platform] ?? 0) + 1;
+    continue;
+  }
+
+  // Don't add a second entry if the speaker already has this platform.
+  $duplicate = FALSE;
+  foreach ($node->get('field_social_media_links')->referencedEntities() as $existing) {
+    $existing_tid = $existing->field_platform->target_id ?? NULL;
+    if ($existing_tid == $terms[$platform]) {
+      $duplicate = TRUE;
+      break;
+    }
+  }
+
+  if ($duplicate) {
+    $already_had++;
+    continue;
+  }
+
+  $would[$platform] = ($would[$platform] ?? 0) + 1;
+
+  if ($store_uri !== $uri) {
+    $rewritten++;
+  }
+
+  if ($live) {
+    $paragraph = \Drupal\paragraphs\Entity\Paragraph::create([
+      'type' => 'social_media_link',
+      'field_platform' => ['target_id' => $terms[$platform]],
+      'field_url' => ['uri' => $store_uri],
+    ]);
+    $paragraph->save();
+
+    $node->get('field_social_media_links')->appendItem([
+      'target_id' => $paragraph->id(),
+      'target_revision_id' => $paragraph->getRevisionId(),
+    ]);
+    $node->save();
+
+    $migrated++;
+  }
+
+  if ($limit && array_sum($would) >= $limit) {
+    break;
+  }
+}
+
+arsort($would);
+arsort($skip);
+
+print ($live ? "MIGRATED:\n" : "WOULD MIGRATE:\n");
+foreach ($would as $platform => $n) {
+  printf("  %-10s %d\n", $platform, $n);
+}
+print "  " . str_repeat('-', 16) . "\n";
+printf("  %-10s %d\n", 'TOTAL', array_sum($would));
+
+print "\n" . ($live ? "SKIPPED" : "WOULD SKIP") . " (not a social profile):\n";
+foreach ($skip as $host => $n) {
+  printf("  %-28s %d\n", $host, $n);
+}
+print "  " . str_repeat('-', 34) . "\n";
+printf("  %-28s %d\n", 'TOTAL', array_sum($skip));
+
+if ($no_term) {
+  print "\nRECOGNIZED BUT NO MATCHING TERM (would need adding to the vocabulary):\n";
+  foreach ($no_term as $platform => $n) {
+    printf("  %-10s %d\n", $platform, $n);
+  }
+}
+
+print "\nBroken links rebuilt as x.com URLs:    $rewritten\n";
+print "Already had that platform, left alone: $already_had\n";
+print "Total speakers with a Twitter value:   " . count($nids) . "\n";
+
+if ($live) {
+  print "Paragraphs created:                    $migrated\n";
+}
+else {
+  print "\nNothing was changed. Re-run with -- --live to apply.\n";
+}
+
+if ($limit && array_sum($would) >= $limit) {
+  print "\nStopped early at the limit of $limit. Re-run without --limit for the rest.\n";
+}
+
+print "\n";


### PR DESCRIPTION
## Summary

2 of 3. Migrates existing `field_twitter_profile` values into the `field_social_media_links` field from #301. Next PR takes the old Twitter field off the form and the profile.

One off drush script. Doesn't delete anything, doesn't create revisions, doesn't send email, and is safe to rerun.

```bash
drush php:script migrate-twitter-to-social-links.php                      # dry run
drush php:script migrate-twitter-to-social-links.php -- --live            # writes
drush php:script migrate-twitter-to-social-links.php -- --live --limit=5  # writes 5, stops
```

On a copy of prod it migrates 1,159 and skips 16 that aren't social profiles. 53 were saved as `socallinuxexpo.org/@handle` instead of the platform's domain, so those get rebuilt as `x.com` links. I spot checked some and they resolve to real profiles. Ilan looked over the list too.

`MIGRATIONS.md` has the steps, what to verify, and how to roll back.

## Before it runs on prod

The 7 platform terms need to exist in the `social_media_platforms` vocabulary. They're content, not config, so they don't come with the deploy.

## Testing

Ran it end to end locally against a copy of production. Dry and live report the same numbers, a second run migrates 0, and `--limit=5` stops at 5. Checked all 1,175 values against the platform they were detected as, which caught `twitter.com/@handle` being read as Mastodon since both use `/@username`. Fixed and re-verified.