### PR TITLE
[READY]-[ISSUE-242]-Hide legacy Twitter field on the form and profile

### DIFF
--- a/config/sync/core.entity_form_display.node.speaker.default.yml
+++ b/config/sync/core.entity_form_display.node.speaker.default.yml
@@ -42,7 +42,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 20
+    weight: 19
     region: content
     settings:
       rows: 9
@@ -58,13 +58,13 @@ content:
     third_party_settings: {  }
   field_age:
     type: options_select
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   field_education:
     type: options_select
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -78,13 +78,13 @@ content:
     third_party_settings: {  }
   field_employment_status:
     type: options_select
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   field_ethnicity:
     type: options_select
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -98,13 +98,13 @@ content:
     third_party_settings: {  }
   field_gender:
     type: options_select
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_household_income:
     type: options_select
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -126,7 +126,7 @@ content:
     third_party_settings: {  }
   field_marital_status:
     type: options_select
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -140,7 +140,7 @@ content:
     third_party_settings: {  }
   field_phone:
     type: string_textfield
-    weight: 21
+    weight: 20
     region: content
     settings:
       size: 60
@@ -148,7 +148,7 @@ content:
     third_party_settings: {  }
   field_postal_code:
     type: string_textfield
-    weight: 17
+    weight: 16
     region: content
     settings:
       size: 60
@@ -156,7 +156,7 @@ content:
     third_party_settings: {  }
   field_profile_photo:
     type: image_image
-    weight: 10
+    weight: 9
     region: content
     settings:
       progress_indicator: throbber
@@ -171,7 +171,7 @@ content:
     third_party_settings: {  }
   field_social_media_links:
     type: paragraphs
-    weight: 9
+    weight: 8
     region: content
     settings:
       title: Paragraph
@@ -196,17 +196,9 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-  field_twitter_profile:
-    type: link_default
-    weight: 8
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
   field_user_account:
     type: entity_reference_autocomplete_tags
-    weight: 11
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -224,33 +216,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 28
+    weight: 27
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 25
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 23
+    weight: 22
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 26
+    weight: 25
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 24
+    weight: 23
     region: content
     settings:
       display_label: true
@@ -265,7 +257,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 22
+    weight: 21
     region: content
     settings:
       match_operator: CONTAINS
@@ -274,9 +266,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 27
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   field_legacy_uid: true
+  field_twitter_profile: true

--- a/config/sync/core.entity_form_display.node.speaker.speaker.yml
+++ b/config/sync/core.entity_form_display.node.speaker.speaker.yml
@@ -53,7 +53,7 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 21
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -172,7 +172,7 @@ content:
     third_party_settings: {  }
   field_social_media_links:
     type: paragraphs
-    weight: 19
+    weight: 18
     region: content
     settings:
       title: Paragraph
@@ -197,14 +197,6 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-  field_twitter_profile:
-    type: link_default
-    weight: 18
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
   field_website:
     type: link_default
     weight: 8
@@ -215,33 +207,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 26
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 24
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 22
+    weight: 21
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 27
+    weight: 26
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 23
+    weight: 22
     region: content
     settings:
       display_label: true
@@ -256,7 +248,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 20
+    weight: 19
     region: content
     settings:
       match_operator: CONTAINS
@@ -265,10 +257,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 25
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   field_legacy_uid: true
+  field_twitter_profile: true
   field_user_account: true

--- a/web/themes/custom/scale/templates/node/node--speaker.html.twig
+++ b/web/themes/custom/scale/templates/node/node--speaker.html.twig
@@ -9,14 +9,6 @@
       </div>
     {% endif %}
 
-    {% if node.field_twitter_profile.uri %}
-      <div class="text-2xl">
-        <a href="{{ node.field_twitter_profile.uri }}" target="_blank" class="text-black" title="Twitter">
-          <i class="fa-brands fa-x-twitter"></i>
-        </a>
-      </div>
-    {% endif %}
-
     {% set social_icons = {
       'Mastodon': 'fa-mastodon',
       'X': 'fa-x-twitter',


### PR DESCRIPTION
## Summary

3 of 3. Takes the legacy `field_twitter_profile` off the speaker form and out of the profile template, now that #307 migrates its values into the new social links field.

**Don't merge until the migration has actually run on prod.** Merging early means the old Twitter icon disappears before the new links exist.

The field itself stays, along with all 1,174 original values. This only removes it from the two speaker form displays and the template, so there's still a way back. Deleting it properly can be a follow up once we're confident.

## Changes

- Speakers no longer see a Twitter Profile box on their edit form
- Profiles stop rendering the old Twitter icon, so no more duplicate X icon next to the migrated one
- 16 speakers had blogs or personal sites in there rather than a social profile, so they lose that icon.

Both form displays are changed, `default` and `speaker`, so it applies to admins and speakers alike.

## Testing

Checked as a non-admin speaker that the Twitter Profile field is gone and social links still saves. Confirmed a migrated speaker now shows one X icon instead of two, and that speakers with no links render cleanly.