### PR TITLE
[REVIEW]-[ISSUE-306]- Create URL alias pattern for blogs to generate a url using a slug instead of node iD

### DIFF
--- a/config/sync/pathauto.pattern.blog_article.yml
+++ b/config/sync/pathauto.pattern.blog_article.yml
@@ -1,0 +1,22 @@
+uuid: c5d92457-8edd-4eed-9a50-a15599e16b72
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: blog_article
+label: Blog/Article
+type: 'canonical_entities:node'
+pattern: 'scale/[node:field_scale_events]/blog/[node:title]'
+selection_criteria:
+  6c27fa4b-6cf1-4721-bd7c-d6fc08e157ed:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 6c27fa4b-6cf1-4721-bd7c-d6fc08e157ed
+    context_mapping:
+      node: node
+    bundles:
+      article: article
+selection_logic: and
+weight: -5
+relationships: {  }


### PR DESCRIPTION
### Issue

Content type `article` that is used for blog posts was not generating an automatic url alias and instead used a pattern. For example, https://www.socallinuxexpo.org/node/26857 should instead automatically generate a URL such as https://www.socallinuxexpo.org/23x/blog/call-for-proposals-open. To do this, the URLs were being manually input into the URL alias field when creating/updating an `article` node.

### Changes

Created a new URL Alias Pattern in /admin/config/search/path/patterns called `Blog/Article` to generate automatic aliases using this convention:

`/scale/EVENT/blog/NODE-TITLE`

There are three conventions that can be generated with this URL pattern:

- A blog article with a single event (just 24x)
`/scale/24x/blog/karens-drupal-blog`
<img width="1439" height="663" alt="single-event" src="https://github.com/user-attachments/assets/99e28c1b-6671-472f-9f1a-c4a86c62295a" />

- A blog article with two or more events (24x, 23x, 22x, or more). **Recommendation for this case** is to go into the article and manually delete one or both of the events from the URL alias.
`/scale/24x-23x/blog/blog-two-events`
<img width="1440" height="596" alt="two-events" src="https://github.com/user-attachments/assets/b350f438-2a23-4b59-aa61-f14cf40b1204" />

- A blog article with no events
`/scale/blog/blog-no-event`
<img width="1438" height="596" alt="no-event" src="https://github.com/user-attachments/assets/b918f641-9fc4-49e8-b765-d6fe6d68d42a" />

### Note
- URL pattern will generate the URL alias regardless of how long the headline is. A blog article with the headline "This is a blog with a really long title although headlines should not be longer than 65 characters" will generate the url
`/scale/blog/blog-really-long-title-although-headlines-should-not-be-longer-65-characters`

The URL pattern will not truncate the URL, but the recommendation/best practice is to not have a headline longer than 65 characters. Should an article have a headline that is over 65 characters and generates a long URL, the URL can be manually re-worded in URL Alias when editing node.
<img width="1440" height="677" alt="long-title" src="https://github.com/user-attachments/assets/39558b70-b2b1-4a51-8264-685b32509a71" />
